### PR TITLE
Updated Docker build to use Medley Release Assets

### DIFF
--- a/.github/workflows/buildDocker.yml
+++ b/.github/workflows/buildDocker.yml
@@ -5,9 +5,11 @@ name: Build Medley Docker image
 
 # Run this workflow on push to master
 on:
-  push:
-    branches:
-      - master
+  workflow_dispatch:
+
+#  push:
+#    branches:
+#      - master
 
 # Jobs that compose this workflow
 jobs:
@@ -23,20 +25,22 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=interlisp/${GITHUB_REPOSITORY#*/}
+          DOCKER_IMAGE=billstumbo/${GITHUB_REPOSITORY#*/}
           VERSION=latest
           SHORTREF=${GITHUB_SHA::8}
 
           # If this is git tag, use the tag name as a docker tag
           if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/v}
+            VERSION=${GITHUB_REF#refs/tags/}
           fi
+          echo ${VERSION}
+          env
           TAGS="${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:${SHORTREF}"
 
-          # If the VERSION looks like a version number, assume that
+          # If the VERSION looks like medley followed by a date, assume that
           # this is the most recent version of the image and also
           # tag it 'latest'.
-          if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+          if [[ $VERSION =~ ^medley-[0-9]{1,6}.$ ]]; then
             TAGS="$TAGS,${DOCKER_IMAGE}:latest"
           fi
 
@@ -44,6 +48,16 @@ jobs:
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=docker_image::${DOCKER_IMAGE}
           echo ::set-output name=build_time::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo ::set-output name=version::${VERSION}
+
+      # Download Medley Release Assets
+      - name: Download Release Assets
+        uses: robinraju/release-downloader@v1.2
+        with:
+          repository: Interlisp/medley
+          token: ${{ secrets.GITHUB_TOKEN }}
+          latest: true
+          fileName: "*"
 
       # Setup Docker Machine Emulation environment
       - name: Set up QEMU

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM interlisp/maiko:latest
 ARG BUILD_DATE
 LABEL name="Medley"
+# LABEL tags=${tags}
 LABEL description="The Medley Interlisp environment"
 LABEL url="https://github.com/Interlisp/medley"
 LABEL build-time=$BUILD_DATE
@@ -9,8 +10,8 @@ RUN apt-get update && apt-get install -y tightvncserver
 
 EXPOSE 5900
 
-# Need to refine this down to only needed directories.
-COPY . /app/medley
+# Copy and uncompress loadup and required source files.
+ADD *.tgz /app
 
 WORKDIR /app/medley
 


### PR DESCRIPTION
Update Docker Build:
 - Use Medley Releases as opposed to bulk copy
 - Change action to run on demand an not on commit